### PR TITLE
Update config_ignore version dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   },
   "require": {
     "acquia/cohesion": ">=6.8.0",
-    "drupal/config_ignore": "^1 | ^2",
+    "drupal/config_ignore": "^1 | ^2 | ^3",
     "drupal/config_split": "^1 | ^2"
   },
   "autoload": {


### PR DESCRIPTION
ACMS recently updated its dependencies to use config-ignore 3.x https://git.drupalcode.org/project/acquia_cms_common/-/blob/1.x/composer.json#L18

This prevents blt-site-studio from being installed on an ACMS project created using the latest ACMS starterkit. 
